### PR TITLE
fix(bash-report): generate .diff-files instead of .txt (#55)

### DIFF
--- a/bash/generate-git-report/report.sh
+++ b/bash/generate-git-report/report.sh
@@ -19,7 +19,7 @@ generate_single_report() {
     --pretty=format:"%Cblue%h%Creset - %Cred%an:%Creset %Cgreen%s%Creset" \
     -p \
     --no-merges \
-    > "$report_folder/$folder_name.txt"
+    > "$report_folder/$folder_name.diff"
 
   cd "$current_folder"
 }

--- a/bash/generate-git-report/run.sh
+++ b/bash/generate-git-report/run.sh
@@ -41,7 +41,7 @@ log "Generating a daily report"
 
 ## Generate a general report
 ### Remove an old report file
-daily_report="$reports_base/$(date +%F).txt"
+daily_report="$reports_base/$(date +%F).diff"
 if [[ -f "$daily_report" ]]; then
   rm "$daily_report"
 fi


### PR DESCRIPTION
It's better saving reports to the .diff-files instead of .txt because .diff-files have highlight.

PR for the issue #50